### PR TITLE
Feature/more metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,14 @@
 build-service:
 	cd service && go build -a -o ./main .
 
-run-service: build-service
+run-service-a:
+	SERVICE_NAME="service-a" \
+	PORT=9091 \
+	./service/main
+
+run-service-b:
+	SERVICE_NAME="service-b" \
+	PORT=9092 \
 	./service/main
 
 build-img-service:

--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.13.5 as bd
 WORKDIR /github.com/layer5io/sample-app-service
 ADD . .
-RUN GOPROXY=direct GOSUMDB=off go build -a -o /main .
-CMD ["/main"]
+RUN GOPROXY=direct GOSUMDB=off go build -a -o ./main .
+CMD ["./main"]

--- a/service/main.go
+++ b/service/main.go
@@ -127,6 +127,10 @@ func call(w http.ResponseWriter, r *http.Request) {
 	w.Write(bytes)
 }
 
+func echo(w http.ResponseWriter, req *http.Request) {
+	req.Write(w)
+}
+
 func metrics(w http.ResponseWriter, req *http.Request) {
 	if req.Method == http.MethodGet {
 		w.Header().Set("Content-Type", "application/json")
@@ -150,6 +154,7 @@ func metrics(w http.ResponseWriter, req *http.Request) {
 
 func main() {
 	logrus.SetOutput(os.Stdout)
+	logrus.SetLevel(logrus.DebugLevel)
 
 	serviceName = os.Getenv("SERVICE_NAME")
 	if serviceName == "" {
@@ -166,9 +171,10 @@ func main() {
 	requestsReceived = []string{}
 
 	mux := http.NewServeMux()
+
 	mux.Handle("/call", MetricsMiddleware(http.HandlerFunc(call)))
 	mux.Handle("/metrics", http.HandlerFunc(metrics))
-	logrus.Debugf("Started serving at: 9091")
-	println("Started serving at: " + port)
+	mux.Handle("/echo", http.HandlerFunc(echo))
+	logrus.Infof("Started serving at: %s", port)
 	http.ListenAndServe(":"+port, mux)
 }

--- a/service/main.go
+++ b/service/main.go
@@ -5,42 +5,49 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
-	"strconv"
 	"strings"
 	"sync"
 
 	logrus "github.com/sirupsen/logrus"
 )
 
-var requestsReceived int
-var responsesSucceeded int
-var responsesFailed int
+var requestsReceived []string
+var responsesSucceeded []string
+var responsesFailed []string
 var mutex sync.Mutex
 
-func exclusive(fn func()) {
+func execExclusive(fn func()) {
 	defer mutex.Unlock()
 	mutex.Lock()
 	fn()
 }
 
+const serviceID = "ServiceName"
+
+var serviceName string
+
 func MetricsMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		exclusive(func() { requestsReceived++ })
+		execExclusive(func() {
+			svcName := r.Header.Get(serviceID)
+			if svcName == "" {
+				svcName = "Unidentified"
+			}
+			requestsReceived = append(requestsReceived, svcName)
+		})
 		next.ServeHTTP(w, r)
 	})
 }
 
-func call(w http.ResponseWriter, req *http.Request) {
-	if req.Method != http.MethodPost {
-		http.Error(w, "Method not defined", http.StatusBadRequest)
-		logrus.Errorf("Method not defined")
+func call(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
 		return
 	}
 
-	defer req.Body.Close()
+	defer r.Body.Close()
 
-	var data map[string]string
-	bytes, err := ioutil.ReadAll(req.Body)
+	var data map[string]interface{}
+	bytes, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		http.Error(w, "Error reading body", http.StatusBadRequest)
 		logrus.Errorf("Error reading body: %s", err.Error())
@@ -59,18 +66,38 @@ func call(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	host := data["host"]
-	body := data["body"]
+	url := data["url"].(string)
+	method := data["method"].(string)
+	headers := data["headers"]
+	body := data["body"].(string)
 
-	if host == "" {
-		return
+	var req *http.Request
+	if method == http.MethodPost || method == http.MethodPatch || method == http.MethodPut {
+		req, err = http.NewRequest(method, url, strings.NewReader(body))
+		if err != nil {
+			logrus.Errorf("Error creating request %s", err.Error())
+			// TODO err handling
+		}
+	} else {
+		req, err = http.NewRequest(method, url, nil)
+		if err != nil {
+			logrus.Errorf("Error creating request %s", err.Error())
+		}
 	}
 
-	var resp *http.Response
-	if body != "" {
-		resp, err = http.Post(host, "application/json", strings.NewReader(body))
-	} else {
-		resp, err = http.Get(host)
+	client := http.Client{}
+
+	if headers != nil {
+		headers := headers.(map[string]interface{})
+		for key, val := range headers {
+			req.Header.Add(key, val.(string))
+		}
+		req.Header.Add(serviceID, serviceName)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		logrus.Errorf("Error completing the request %s", err.Error())
 	}
 
 	logrus.Debugf("Call response: %v", resp)
@@ -82,9 +109,13 @@ func call(w http.ResponseWriter, req *http.Request) {
 
 	if resp.StatusCode >= 200 && resp.StatusCode < 400 {
 		w.WriteHeader(http.StatusOK)
-		exclusive(func() { responsesSucceeded++ })
+		execExclusive(func() {
+			responsesSucceeded = append(responsesSucceeded, url)
+		})
 	} else {
-		exclusive(func() { responsesFailed++ })
+		execExclusive(func() {
+			responsesFailed = append(responsesFailed, url)
+		})
 	}
 
 	bytes, err = ioutil.ReadAll(resp.Body)
@@ -99,17 +130,19 @@ func call(w http.ResponseWriter, req *http.Request) {
 func metrics(w http.ResponseWriter, req *http.Request) {
 	if req.Method == http.MethodGet {
 		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(map[string]string{
-			"responsesSucceeded": strconv.Itoa(responsesSucceeded),
-			"responsesFailed":    strconv.Itoa(responsesFailed),
-			"requestsReceived":   strconv.Itoa(requestsReceived),
+		if err := json.NewEncoder(w).Encode(map[string][]string{
+			"responsesSucceeded": responsesSucceeded,
+			"responsesFailed":    responsesFailed,
+			"requestsReceived":   requestsReceived,
 		}); err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 		}
 	} else if req.Method == http.MethodDelete {
-		responsesSucceeded = 0
-		responsesFailed = 0
-		requestsReceived = 0
+		execExclusive(func() {
+			responsesSucceeded = []string{}
+			responsesFailed = []string{}
+			requestsReceived = []string{}
+		})
 	} else {
 		http.Error(w, "Method not defined", http.StatusBadRequest)
 	}
@@ -118,8 +151,24 @@ func metrics(w http.ResponseWriter, req *http.Request) {
 func main() {
 	logrus.SetOutput(os.Stdout)
 
+	serviceName = os.Getenv("SERVICE_NAME")
+	if serviceName == "" {
+		serviceName = "Default"
+	}
+
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "9091"
+	}
+
+	responsesSucceeded = []string{}
+	responsesFailed = []string{}
+	requestsReceived = []string{}
+
 	mux := http.NewServeMux()
 	mux.Handle("/call", MetricsMiddleware(http.HandlerFunc(call)))
 	mux.Handle("/metrics", http.HandlerFunc(metrics))
-	http.ListenAndServe(":9091", mux)
+	logrus.Debugf("Started serving at: 9091")
+	println("Started serving at: " + port)
+	http.ListenAndServe(":"+port, mux)
 }


### PR DESCRIPTION
```shell
# builds the service
make build-service

# Run the following to start service-b (localhost:9092)
make run-service-b

# Run the following in another terminal to start service-a (localhost:9091)
make run-service-a
```

Run the following command to make a request to service-a which inturn will make request to service-b.
```shell
curl --location --request POST 'http://localhost:9091/call' \
--header 'Content-Type: application/json' \
--data-raw '{
"url": "http://localhost:9092/echo",
"body": "",
"method": "GET",
"headers": {
	"head": "tail"
}
}'
``` 
To see metrics:
```shell
# service-a
curl --location --request GET 'localhost:9091/metrics'

# service-b
curl --location --request GET 'localhost:9091/metrics'
```

sample output for the metrics :
Service-a:
```json
{
    "ReqReceived": [
        "Unidentified"
    ],
    "RespSucceeded": [
        {
            "URL": "http://localhost:9092/echo",
            "Method": "GET",
            "Headers": {
                "head": "tail"
            }
        }
    ],
    "RespFailed": []
}
```

Service-b:
```json
{
    "ReqReceived": [
        "service-a"
    ],
    "RespSucceeded":[],
    "RespFailed": []
}
```